### PR TITLE
Display message info and manage menus

### DIFF
--- a/frontend/app/src/app/components/chatting/components/chat-list/chat-list.component.html
+++ b/frontend/app/src/app/components/chatting/components/chat-list/chat-list.component.html
@@ -77,6 +77,7 @@
                 <!-- Text content -->
                 <div  [matMenuTriggerFor]="msgMenu"
      #t="matMenuTrigger"
+     [matMenuTriggerData]="{ trigger: t, message: m }"
      (contextmenu)="$event.preventDefault(); t.openMenu()" class="message-content">{{ m.content }}</div>
 
                 <!-- File/Image
@@ -111,6 +112,19 @@
                 <button mat-menu-item (click)="forward(m)"><mat-icon>forward</mat-icon><span>Forward</span></button>
                 <button mat-menu-item (click)="deleteForMe(m)"><mat-icon>delete</mat-icon><span>Delete</span></button>
                 <button mat-menu-item (click)="pin(m)"><mat-icon>push_pin</mat-icon><span>Pin</span></button>
+                <button mat-menu-item (click)="openInfoFromContext(data?.trigger, infoMenu, data?.message?.messageId)"><mat-icon>info</mat-icon><span>Info</span></button>
+  </ng-template>
+              </mat-menu>
+
+              <!-- Info Menu -->
+              <mat-menu #infoMenu="matMenu">
+  <ng-template matMenuContent let-data="matMenuTriggerData">
+    <div style="min-width: 250px; max-width: 300px; padding: 12px;">
+      <h6 style="margin-bottom: 8px; font-weight: 600;">Message Info</h6>
+      <p style="margin: 4px 0; color: gray;"><strong>Message ID:</strong> {{ data?.message?.messageId }}</p>
+      <p style="margin: 4px 0; color: gray;"><strong>Delivered:</strong> {{ (data?.message?.messageStatus === MessageStatus.DELIVERED || data?.message?.messageStatus === MessageStatus.READ) ? 'Yes' : 'No' }}</p>
+      <p style="margin: 4px 0; color: gray;"><strong>Read:</strong> {{ data?.message?.messageStatus === MessageStatus.READ ? 'Yes' : 'No' }}</p>
+    </div>
   </ng-template>
               </mat-menu>
 

--- a/frontend/app/src/app/components/chatting/components/chat-list/chat-list.component.ts
+++ b/frontend/app/src/app/components/chatting/components/chat-list/chat-list.component.ts
@@ -7,7 +7,7 @@ import { ActivatedRoute } from '@angular/router';
 import { FormsModule } from '@angular/forms';
 import { HttpErrorResponse } from '@angular/common/http';
 import { MessageResponse, MessageStatus } from '../../models/message-response';
-import { MatMenuModule, MatMenuTrigger } from '@angular/material/menu';
+import { MatMenu, MatMenuModule, MatMenuTrigger } from '@angular/material/menu';
 import { MatIconModule } from "@angular/material/icon";
 import { ViewChild } from '@angular/core';
 
@@ -207,6 +207,7 @@ export class ChatListComponent {
 
 
   @ViewChild('t') menuTrigger!: MatMenuTrigger;
+  lastMessageMenuTrigger?: MatMenuTrigger;
 
   @HostListener('document:click', ['$event'])
   onDocumentClick(event: MouseEvent) {
@@ -214,5 +215,23 @@ export class ChatListComponent {
     if (this.menuTrigger?.menuOpen) {
       this.menuTrigger.closeMenu();
     }
+  }
+
+  openInfoFromContext(parentTrigger: MatMenuTrigger | undefined, infoMenu: MatMenu, messageId?: number): void {
+    if (!parentTrigger) {
+      return;
+    }
+
+    const originalMenu = parentTrigger.menu;
+    parentTrigger.closeMenu();
+
+    parentTrigger.menu = infoMenu;
+    setTimeout(() => {
+      parentTrigger.openMenu();
+      const sub = parentTrigger.menuClosed.subscribe(() => {
+        parentTrigger.menu = originalMenu;
+        sub.unsubscribe();
+      });
+    }, 0);
   }
 }


### PR DESCRIPTION
Add WhatsApp-like message info display by transitioning from the message context menu to a dedicated info menu.

This PR fixes an issue where `matMenuTriggerData` was undefined when trying to open the info menu directly. It now correctly passes the `MatMenuTrigger` and message data, allowing a helper function to smoothly close the message context menu and open the info menu, providing a better user experience for viewing message delivery and read statuses.

---
<a href="https://cursor.com/background-agent?bcId=bc-0c58d835-7fee-49a0-b666-3013807dc87c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-0c58d835-7fee-49a0-b666-3013807dc87c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

